### PR TITLE
PoC consume hmac funcs

### DIFF
--- a/cpp/op-aws-lc.cpp
+++ b/cpp/op-aws-lc.cpp
@@ -1,6 +1,8 @@
 #include "op-aws-lc.h"
 #include "macros.h"
 #include "librn_aws_lc.h"
+#include <iomanip>
+#include <iostream>
 
 namespace opawslc {
 namespace jsi = facebook::jsi;
@@ -10,9 +12,57 @@ void install(jsi::Runtime &rt,
              std::shared_ptr<react::CallInvoker> invoker) {
 
   auto hmac = HOST_STATIC_FN("makeHmac") {
-    void *key;
-    awsrc::generate_hmac_sha256_key(&key);
-    return jsi::String::createFromUtf8(rt, "Hello, World!");
+    awsrc::CHmacKeyHandle *key = awsrc::generate_hmac_key(awsrc::CHmacAlgorithm::SHA256);
+    
+    const char* message = "Hello, this is a test message to be signed";
+    const size_t message_len = strlen(message);
+    unsigned char tag_buffer[64];
+    size_t tag_len;
+
+    awsrc::CHmacError result = awsrc::hmac_sign(
+        key,
+        reinterpret_cast<const unsigned char*>(message),
+        message_len,
+        tag_buffer,
+        &tag_len
+    );
+    
+    std::string tag_hex = "";
+    if (result == awsrc::CHmacError::Success) {
+        // Convert tag to hex string for display
+      std::stringstream ss;
+      for (size_t i = 0; i < tag_len; ++i) {
+          ss << std::hex << std::setw(2) << std::setfill('0')
+             << static_cast<int>(tag_buffer[i]);
+      }
+      tag_hex = ss.str();
+      std::cout << "HMAC Tag (hex): " << tag_hex << std::endl;
+      awsrc::CHmacError verifyResult = awsrc::hmac_verify(key,
+                                                    reinterpret_cast<const unsigned char*>(message),
+                                                    message_len,
+                                                    tag_buffer,
+                                                    tag_len);
+      if (verifyResult == awsrc::CHmacError::Success){
+        std::cout << "Message verified" << std::endl;
+      }
+      char tampered_message[100];
+      strcpy(tampered_message, message);
+      tampered_message[0] = 'h';  // Change first letter
+      awsrc::CHmacError verifyTamperedResult = awsrc::hmac_verify(key,
+                                                    reinterpret_cast<const unsigned char*>(tampered_message),
+                                                    message_len,
+                                                    tag_buffer,
+                                                    tag_len);
+      if (verifyTamperedResult != awsrc::CHmacError::Success){
+        std::cout << "Tampered message verify message success" << std::endl;
+      } else {
+        std::cout << "Tamper verification failed" << std::endl;
+      }
+    } else {
+        std::cerr << "HMAC signing failed with error code: " << static_cast<int>(result) << std::endl;
+    }
+    awsrc::hmac_free(key);
+    return jsi::String::createFromUtf8(rt, tag_hex);
   });
 
   jsi::Object proxy = jsi::Object(rt);

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,14 +1,15 @@
 import { Text, View, StyleSheet } from 'react-native';
-import { generateHmacKey } from 'op-aws-lc';
+import { hmac } from 'op-aws-lc';
 
-const key = generateHmacKey();
+const key = hmac();
 
 export default function App() {
   return (
     <View style={styles.container}>
       <Text>
-        Hmac Key should have been generated. Hmac object is there?{' '}
-        {!!key ? 'Yes' : 'No'}
+        Hmac Key should have been generated and signed a hello message. Signed
+        message is:
+        {key}
       </Text>
     </View>
   );


### PR DESCRIPTION
Call rust functions from C
1. Generate the key
2. Sign and print the hex value of the signed message
3. Verify the same message
4. Tamper the message and verify again